### PR TITLE
fix module name

### DIFF
--- a/lib/Dist/Build/XS/Export.pm
+++ b/lib/Dist/Build/XS/Export.pm
@@ -49,7 +49,7 @@ sub add_methods {
 
 =head1 SYNOPSIS
 
- load_module('Dist::Build::Export');
+ load_module('Dist::Build::XS::Export');
  export_headers(
      module => 'Foo::Bar',
      dir    => 'include',


### PR DESCRIPTION
I think Dist::Build::Export should be Dist::Build::XS::Export